### PR TITLE
Support naming contexts

### DIFF
--- a/lib/ermir/evil_registry.rb
+++ b/lib/ermir/evil_registry.rb
@@ -100,12 +100,15 @@ module Ermir
       bind_key_size = @socket.read(2).unpack("S>")[0]
       bind_key = @socket.read(bind_key_size)
       if @socket.getbyte.eql?(TransportConstants::TC_OBJECT)
-        if @socket.getbyte.eql?(TransportConstants::TC_PROXYCLASSDESC)
+        if [TransportConstants::TC_PROXYCLASSDESC, TransportConstants::TC_CLASSDESC].include?(@socket.getbyte)
           interfaces_count = @socket.read(4).unpack("L>")[0]
           implemented_interfaces = []
           interfaces_count.times do
             interface_name_size = @socket.read(2).unpack("S>")[0]
-            return "the received interface name length exceeds the max length" if interface_name_size > 100
+            if interface_name_size > 100
+              Utils.print_time_msg("the received interface name length exceeds the max length, breaking the read...")
+              break
+            end
             implemented_interfaces << @socket.read(interface_name_size)
           end
           if implemented_interfaces[0] == "java.rmi.Remote"

--- a/lib/ermir/evil_registry.rb
+++ b/lib/ermir/evil_registry.rb
@@ -109,9 +109,9 @@ module Ermir
             implemented_interfaces << @socket.read(interface_name_size)
           end
           if implemented_interfaces[0] == "java.rmi.Remote"
-            Utils.print_rmi_transport_msg("Ermir.#{rebind && 're'}bind(#{bind_key.inspect}, new <class (?) implements #{implemented_interfaces[1]}>()) was called by the remote peer.", @peeraddr)
+            Utils.print_rmi_transport_msg("Ermir.#{rebind && 're' || ''}bind(#{bind_key.inspect}, new <class (?) implements #{implemented_interfaces[1]}>()) was called by the remote peer.", @peeraddr)
           else
-            Utils.print_rmi_transport_msg("Ermir.#{rebind && 're'}bind(#{bind_key.inspect}, <java.lang.reflect.Proxy handling <#{implemented_interfaces*', '}> interfaces>) was called by the remote peer.", @peeraddr)
+            Utils.print_rmi_transport_msg("Ermir.#{rebind && 're' || ''}bind(#{bind_key.inspect}, <java.lang.reflect.Proxy handling <#{implemented_interfaces*', '}> interfaces>) was called by the remote peer.", @peeraddr)
           end
         else
           return "received a corrupted RMI message body"


### PR DESCRIPTION
This PR adds support for naming contexts, which uses `TC_CLASSDESC` instead of `TC_PROXYCLASSDESC`.

If a context is created without a specific context factory (eg: `com.sun.jndi.ldap.LdapCtxFactory` for LDAP), providing the `rmi://` protocol will make the context to use the vulnerable `[ub|re]bind`... methods that you explain in the README.

You can quickly test using:

```java
InitialDirContext ctx = new InitialDirContext();
ctx.bind("rmi://ermir", new Reference(""));
```

Thanks for your research and creating ermir!